### PR TITLE
Fix a bug in AnimatedSwitch

### DIFF
--- a/src/AnimatedSwitch.js
+++ b/src/AnimatedSwitch.js
@@ -4,6 +4,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {matchPath, withRouter} from 'react-router';
+import {TransitionRoute} from './TransitionRoute';
 
 @withRouter
 export class AnimatedSwitch extends React.Component {
@@ -22,6 +23,7 @@ export class AnimatedSwitch extends React.Component {
         super(props, context);
 
         this.activeChild = null;
+
         this.state = {
             status: ''
         }
@@ -40,17 +42,13 @@ export class AnimatedSwitch extends React.Component {
     render() {
         if(this.activeChild && this.status != 'DID_LEAVE') {
             // console.log('active: '+this.status)
-            return this.activeChild ? this.activeChild[0] : null;
-
+            return this.activeChild ? this.activeChild : null;
         }
         else {
             this.activeChild = null;
         }
 
-
-        let found = false;
-
-        let children = React.Children.map(this.props.children, child => {
+        React.Children.forEach(this.props.children, child => {
 
             let match = matchPath(this.props.location.pathname, {
                 path: child.props.path,
@@ -58,22 +56,12 @@ export class AnimatedSwitch extends React.Component {
                 strict: child.props.strict
             });
 
-            if(!found && match) {
-                found = true;
-
-                let clone = React.cloneElement(child, {
-                    onStateChange: (value) => this.onStateChange(value)
-                });
-
+            if(!this.activeChild && match) {
                 this.activeChild = child;
-
-                return clone;
             }
         });
 
-        this.activeChild = children;
-
-        return children ? children[0] : null;
+        return this.activeChild ? this.activeChild : null
     }
 
 }

--- a/src/example/index.js
+++ b/src/example/index.js
@@ -28,7 +28,7 @@ class ExampleApp extends React.Component {
                         <TransitionRoute exact path="/">
                             <Transition>root path</Transition>
                         </TransitionRoute>
-                        <TransitionRoute exact path="/otherPath">
+                        <TransitionRoute path="/otherPath">
                             <Transition>other path</Transition>
                         </TransitionRoute>
                         <TransitionRoute path="/">
@@ -43,6 +43,12 @@ class ExampleApp extends React.Component {
 
 class Transition extends React.Component {
 
+    constructor(props) {
+        super(props);
+
+        console.log('constructor: '+this.props.children);
+    }
+
     componentWillAppear(cb) {
         TweenLite.fromTo(ReactDOM.findDOMNode(this), .5, {x: -100, opacity: 0}, {x: 0, opacity:1, onComplete: () => cb()});
     }
@@ -52,7 +58,7 @@ class Transition extends React.Component {
     }
 
     componentWillEnter(cb) {
-        TweenLite.fromTo(ReactDOM.findDOMNode(this), .5, {x: -100, opacity: 0}, {x: 0, opacity:1, onComplete: () => cb()});
+        TweenLite.fromTo(ReactDOM.findDOMNode(this), .5, {x: 100, opacity: 0}, {x: 0, opacity:1, onComplete: () => cb()});
     }
 
     componentDidEnter() {


### PR DESCRIPTION
Remove the unused property onStateChange on the TransitionRoute, child of
AnimatedSwitch. Also remove the need to clone the child being returned by
render.

Fix the test for AnimatedSwitch which now passes correctly with the
full cycle, including WILL_ENTER/DID_ENTER.