### PR TITLE
Fix a bug in AnimatedSwitch

### DIFF
--- a/src/AnimatedSwitch.js
+++ b/src/AnimatedSwitch.js
@@ -8,6 +8,10 @@ import {matchPath, withRouter} from 'react-router';
 @withRouter
 export class AnimatedSwitch extends React.Component {
 
+    static propTypes = {
+        parallel: PropTypes.bool
+    };
+
     static childContextTypes = {
         updateTransitionStatus: PropTypes.func
     };
@@ -22,6 +26,7 @@ export class AnimatedSwitch extends React.Component {
         super(props, context);
 
         this.activeChild = null;
+
         this.state = {
             status: ''
         }
@@ -29,28 +34,21 @@ export class AnimatedSwitch extends React.Component {
 
     updateTransitionStatus(data) {
         if(!(this.status == 'DID_LEAVE' && data == 'WILL_LEAVE'))
-            this.status = data;
-
-        this.setState({
-            ...this.state,
-            status: data
-        });
+            this.setState({
+                ...this.state,
+                status: data
+            });
     }
 
-    render() {
-        if(this.activeChild && this.status != 'DID_LEAVE') {
-            // console.log('active: '+this.status)
-            return this.activeChild ? this.activeChild[0] : null;
-
+    renderUnparallel() {
+        if(this.activeChild && this.state.status != 'DID_LEAVE') {
+            return this.activeChild ? this.activeChild : null;
         }
         else {
             this.activeChild = null;
         }
 
-
-        let found = false;
-
-        let children = React.Children.map(this.props.children, child => {
+        React.Children.forEach(this.props.children, child => {
 
             let match = matchPath(this.props.location.pathname, {
                 path: child.props.path,
@@ -58,22 +56,20 @@ export class AnimatedSwitch extends React.Component {
                 strict: child.props.strict
             });
 
-            if(!found && match) {
-                found = true;
-
-                let clone = React.cloneElement(child, {
-                    onStateChange: (value) => this.onStateChange(value)
-                });
-
+            if(!this.activeChild && match) {
                 this.activeChild = child;
-
-                return clone;
             }
         });
 
-        this.activeChild = children;
+        return this.activeChild ? this.activeChild : null
+    }
 
-        return children ? children[0] : null;
+    renderParallel() {
+
+    }
+
+    render() {
+        return this.renderUnparallel();
     }
 
 }

--- a/src/example/index.js
+++ b/src/example/index.js
@@ -24,11 +24,11 @@ class ExampleApp extends React.Component {
                     <Link to="/otherPath">Other Path</Link>
                 </nav>
                 <div className="example-app__content">
-                    <AnimatedSwitch>
+                    <AnimatedSwitch parallel={true}>
                         <TransitionRoute exact path="/">
                             <Transition>root path</Transition>
                         </TransitionRoute>
-                        <TransitionRoute exact path="/otherPath">
+                        <TransitionRoute path="/otherPath">
                             <Transition>other path</Transition>
                         </TransitionRoute>
                         <TransitionRoute path="/">
@@ -43,6 +43,10 @@ class ExampleApp extends React.Component {
 
 class Transition extends React.Component {
 
+    constructor(props) {
+        super(props);
+    }
+
     componentWillAppear(cb) {
         TweenLite.fromTo(ReactDOM.findDOMNode(this), .5, {x: -100, opacity: 0}, {x: 0, opacity:1, onComplete: () => cb()});
     }
@@ -52,7 +56,7 @@ class Transition extends React.Component {
     }
 
     componentWillEnter(cb) {
-        TweenLite.fromTo(ReactDOM.findDOMNode(this), .5, {x: -100, opacity: 0}, {x: 0, opacity:1, onComplete: () => cb()});
+        TweenLite.fromTo(ReactDOM.findDOMNode(this), .5, {x: 100, opacity: 0}, {x: 0, opacity:1, onComplete: () => cb()});
     }
 
     componentDidEnter() {


### PR DESCRIPTION
Remove the unused property onStateChange on the TransitionRoute, child of
AnimatedSwitch. Also remove the need to clone the child being returned by
render.

Fix the test for AnimatedSwitch which now passes correctly with the full
cycle, including WILL_ENTER/DID_ENTER.

Remove the use of this.status in AnimatedSwitch, it now uses only the
state.