### PR TITLE
Fix prop issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,3 @@ npm run start:server
 The app will be running at localhost:8080, the build command watches for changes in case you want to play with it, the
 sources are located in src/example.
 
-
-
-In the next update: 
-- maybe emit transition state changes to the parent of TransitionSwitch via props ? In order to sync transition with 
-other parts.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Arnaud Boeglin",
   "license": "MIT",
   "name": "react-router-v4-transition",
-  "version": "0.1.5",
+  "version": "0.1.7",
   "description": "",
   "main": "lib/react-router-v4-transition.js",
   "repository": {

--- a/src/TransitionSwitch.test.js
+++ b/src/TransitionSwitch.test.js
@@ -92,11 +92,11 @@ describe('TransitionSwitch', () => {
         routerWrapper.node.history.push('/'); //We go to "/"
         routerWrapper.node.history.push('/404'); //We go to a non existing route
 
-        expect(wrapper.find(TransitionSwitch).node.state.enteringRoute).toBe(null);
-        expect(wrapper.find(TransitionSwitch).node.state.leavingRoute).not.toBe(null);
+        expect(wrapper.find(TransitionSwitch).node.state.enteringRouteKey).toBe(null);
+        expect(wrapper.find(TransitionSwitch).node.state.leavingRouteKey).not.toBe(null);
 
         jest.runAllTimers(); //We run the leaving transition
-        expect(wrapper.find(TransitionSwitch).node.state.leavingRoute).toBe(null);
+        expect(wrapper.find(TransitionSwitch).node.state.leavingRouteKey).toBe(null);
     });
 
     it('should do nothing if there is no route change', () => {

--- a/src/example/index.js
+++ b/src/example/index.js
@@ -20,6 +20,8 @@ class ExampleApp extends React.Component {
             <div className="example-app">
                 <nav className="example-app__menu">
                     <Link to="/">Home</Link>
+                    <Link to="/aTransition">A Transition</Link>
+                    <Link to="/useRender">Render</Link>
                     <Link to="/otherPath">Other Path</Link>
                     <Link to="/anotherPath">Another Path</Link>
                 </nav>
@@ -28,6 +30,12 @@ class ExampleApp extends React.Component {
                         <Route exact path="/">
                             <Transition>home path</Transition>
                         </Route>
+                        <Route path="/aTransition" component={ATransition}/>
+                        <Route path="/useRender" render={(props) => {
+                            return (
+                                <Transition>use render</Transition>
+                            );
+                        }}/>
                         <Route path="/otherPath">
                             <Transition>other path</Transition>
                         </Route>
@@ -82,6 +90,43 @@ class Transition extends React.Component {
         );
     }
 
+}
+
+class ATransition extends React.Component {
+    constructor(props) {
+        super(props);
+    }
+
+    componentWillAppear(cb) {
+        TweenLite.fromTo(ReactDOM.findDOMNode(this), d, {x: -100, opacity: 0}, {x: 0, opacity:1, onComplete: () => cb()});
+    }
+
+    // componentDidAppear() {
+    //     //do stuff on appear
+    // }
+
+    componentWillEnter(cb) {
+        TweenLite.fromTo(ReactDOM.findDOMNode(this), d, {x: 100, opacity: 0}, {x: 0, opacity:1, onComplete: () => cb()});
+    }
+
+    componentDidEnter() {
+        //do stuff on enter
+    }
+
+    componentWillLeave(cb) {
+        // if(this.mounted)
+        TweenLite.to(ReactDOM.findDOMNode(this), d, {x: -100, opacity:0, onComplete: () => cb()});
+    }
+
+    componentDidLeave() {
+        //do stuff on leave
+    }
+
+    render() {
+        return (
+            <div className="example-app__transition">A Transition</div>
+        );
+    }
 }
 
 ReactDOM.render(


### PR DESCRIPTION
In the current release, the props given to the components under the
TransitionSwitch are not dynamic anymore. This is due to the fact that
we store a clone from this.props.children in the internal state of
TransitionSwitch.

The current solution is to only store the key in the state, and in the
render method we retrive in this.props.children the ones that match the
keys from the state, and we render these

Add support for <Route/>'s component prop. It is the most common use
case and it is now supported.

Add support for <Route/>'s render prop. It is now going to fully support
the react router v4 Route API.

TransitionSwitch no longer returns the underlying Route, but only what
the Route element would render, meaning the child given to the Route
via component, render, or children.